### PR TITLE
--with-ui-type blazor pr example (issue #48)

### DIFF
--- a/Test-UiWithDotnetCli.ps1
+++ b/Test-UiWithDotnetCli.ps1
@@ -8,11 +8,11 @@ dotnet new install .
 
 # Add an UI enabled solution with a first module
 cd test/
-dotnet new modulith -n eShop --with-module Payments --WithUi
+dotnet new modulith -n eShop --with-module Payments --with-ui-type blazor
 
 # Add second and third module. Third module is DDD
 cd eShop
-dotnet new modulith --add basic-module --with-name Shipments --to eShop --WithUi
+dotnet new modulith --add basic-module --with-name Shipments --to eShop --with-ui-type blazor
 dotnet new modulith --add ddd-module --with-name Billing --to eShop
 
 # Add project references. Needed before .Net 9

--- a/working/content/modulith/.template.config/template.json
+++ b/working/content/modulith/.template.config/template.json
@@ -79,12 +79,26 @@
       "fileRename": "Modulith",
       "replaces": "Modulith"
     },
-    "WithUi": {
+    "with-ui-type": {
       "displayName": "With UI",
       "type": "parameter",
-      "description": "Wether to add UI Blazor projects, and configuration",
-      "datatype": "bool",
-      "defaultValue": "false"
+      "description": "Whether to add Blazor or Razor UI projects, and configuration",
+      "datatype": "choice",
+      "defaultValue": "none",
+      "choices": [
+        {
+          "description": "Adds no UI",
+          "choice": "none"
+        },
+        {
+          "description": "Adds Blazor UI",
+          "choice": "blazor"
+        }
+      ]
+    },
+    "WithUi": {
+      "type": "computed",
+      "value": "!(with-ui == 'none')"
     }
   },
   "forms": {


### PR DESCRIPTION
Draft PR demonstating how the functionality descriebd in issue #48 might be introduced.
- introduce a parameter `with-ui-type` with allowed values of none (default) or blazor
- this allows later expansion to other ui types like razor pages etc.
- "WithUi" has been changed to a computed type for now, derived from whether 'none' was selected. Ideally there would be later work to use the approprate 'with-ui-type' choice through the solution but this is simple enough and backwards compatible for now i believe.

