### PR TITLE
Fix #51 Add compatibility messages for automatic project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 [![CI](https://github.com/david-acm/modulith/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/david-acm/modulith/actions/workflows/ci.yml)
 [![NuGet Version](https://img.shields.io/nuget/vpre/Ardalis.Modulith)](https://www.nuget.org/packages/Ardalis.Modulith)
 
-**⚠️This project is a work in progress and will likely receive many API changes before v1.0.0. Please keep this in mind when using, as there will be breaking changes often.**
+* _⚠️This project is a work in progress and will likely receive many API changes before v2.0.0. Please keep this in mind when using, as there will be breaking changes often._
+
+* _⚠️ Automatic project references for new modules are only supported in .Net SDK 9.0.100-preview.7.* and newer. Please make a [manual project reference](#add-a-reference-to-the-new-module) when using earlier versions._
 
 **🆕 Try UI Module generation with Blazor. Jump to [Modules with UI](#modules-with-ui)**
 

--- a/working/content/modulith/.template.config/template.json
+++ b/working/content/modulith/.template.config/template.json
@@ -205,9 +205,10 @@
       "continueOnError": true,
       "manualInstructions": [
         {
-          "text": "Manually add the reference in the web project to the new project"
+          "text": "\n⚠️ This is only supported in .Net SDK 9.0.100-preview.7 and newer.\n🔧 For earlier versions please run:\n\n\tdotnet add Modulith.Web/Modulith.Web.csproj reference NewModule/Modulith.NewModule/Modulith.NewModule.csproj"
         }
       ],
+      "applyFileRenamesToManualInstructions": true,
       "applyFileRenamesToArgs": [
         "targetFiles",
         "reference"
@@ -221,15 +222,16 @@
       }
     },
     {
-      "condition": "(WithUi)",
+      "condition": "(WithUi && !Solution)",
       "description": "Adding the new UI module as a reference to UI shared project",
       "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
       "continueOnError": true,
       "manualInstructions": [
         {
-          "text": "Manually add the reference in the UI project to the new project"
+          "text": "\n⚠️ This is only supported in .Net SDK 9.0.100-preview.7 and newer.\n🔧 For earlier versions please run:\n\n\tdotnet add Shared/Modulith.UI/Modulith.UI.csproj reference NewModule/Modulith.NewModule.UI/Modulith.NewModule.UI.csproj"
         }
       ],
+      "applyFileRenamesToManualInstructions": true,
       "applyFileRenamesToArgs": [
         "targetFiles",
         "reference"
@@ -244,14 +246,15 @@
     },
     {
       "condition": "(!IsSolution)",
-      "description": "Adding the new module as a reference to SharedKernel",
+      "description": "Adding Shared Kernel as a reference to the new module.",
       "actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
       "continueOnError": true,
       "manualInstructions": [
         {
-          "text": "Manually add the reference in the shared kernel project to the new project"
+          "text": "\n⚠️ This is only supported in .Net SDK 9.0.100-preview.7 and newer.\n🔧 For earlier versions please run:\n\n\tdotnet add NewModule/Modulith.NewModule/Modulith.NewModule.csproj reference Shared/Modulith.SharedKernel/Modulith.SharedKernel.csproj"
         }
       ],
+      "applyFileRenamesToManualInstructions": true,
       "applyFileRenamesToArgs": [
         "targetFiles",
         "reference"


### PR DESCRIPTION
Add compatibility message for automatic project reference.

Three changes were made:

## 1. Added a message in the error message when an SDK version that doesn't support automatic references:

```
Unable to determine which project file to add the reference to.
Post action failed.
Manual instructions: 
⚠️ This is only supported in .Net SDK 9.0.100-preview.7 and newer.
🔧 For earlier versions please run:

        dotnet add eShop.Web/eShop.Web.csproj reference Billing/eShop.Billing/eShop.Billing.csproj

Unable to determine which project file to add the reference to.
Post action failed.
Manual instructions: 
⚠️ This is only supported in .Net SDK 9.0.100-preview.7 and newer.
🔧 For earlier versions please run:

        dotnet add Billing/eShop.Billing/eShop.Billing.csproj reference Shared/eShop.SharedKernel/eShop.SharedKernel.csproj
```

## 2. A note in the top of the readme file indicates that this behavior is expected in .Net SDK versions earlier than 9 preview 7

## 3. Removed one of the referencing post actions that was not needed for the solution instantiation. This was attempting to add a reference that was already in place which showed a failed action error message in .net 8